### PR TITLE
Replace .size() with .length

### DIFF
--- a/slider.js
+++ b/slider.js
@@ -12,7 +12,7 @@ jQuery.fn.rbtSlider = function(opt){
             if (opt.height) slider.css('height', opt.height);
             slider.find('.slItem').first().addClass('active');
             if (opt.dots) {
-                var count = slider.find('.slItem').size();
+                var count = slider.find('.slItem').length;
                 slider.append(
                     $('<div/>', {
                         class: 'slDots',


### PR DESCRIPTION
The .size() method is deprecated as of jQuery 1.8. Use the .length property instead.
This change makes this slider work with later jQuery versions (tested on jQuery 3.1.0)